### PR TITLE
Untested fix for MB Electrolyzer/Centrifuge ignoring output chance

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_MultiblockCentrifuge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_MultiblockCentrifuge.java
@@ -137,7 +137,7 @@ public class GT_MetaTileEntity_MultiblockCentrifuge extends GT_MetaTileEntity_Mu
 				this.mMaxProgresstime = maxProgresstime;
 				mOutputItems = new ItemStack[recipe.mOutputs.length];
 		        for (int i = 0; i < recipe.mOutputs.length; i++) {
-		            if (getBaseMetaTileEntity().getRandomNumber(10000) < tRecipe.getOutputChance(i)) {
+		            if (getBaseMetaTileEntity().getRandomNumber(10000) < recipe.getOutputChance(i)) {
 		                this.mOutputItems[i] = recipe.getOutput(i);
 		            }
 		        }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_MultiblockCentrifuge.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_MultiblockCentrifuge.java
@@ -135,7 +135,12 @@ public class GT_MetaTileEntity_MultiblockCentrifuge extends GT_MetaTileEntity_Mu
 
 				this.mEUt = -EUt;
 				this.mMaxProgresstime = maxProgresstime;
-				this.mOutputItems = recipe.mOutputs;
+				mOutputItems = new ItemStack[recipe.mOutputs.length];
+		        for (int i = 0; i < recipe.mOutputs.length; i++) {
+		            if (getBaseMetaTileEntity().getRandomNumber(10000) < tRecipe.getOutputChance(i)) {
+		                this.mOutputItems[i] = recipe.getOutput(i);
+		            }
+		        }
 				this.mOutputFluids = recipe.mFluidOutputs;
 				this.updateSlots();
 				return true;

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_MultiblockElectrolyzer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_MultiblockElectrolyzer.java
@@ -141,7 +141,7 @@ public class GT_MetaTileEntity_MultiblockElectrolyzer  extends GT_MetaTileEntity
 				this.mMaxProgresstime = maxProgresstime;
 				mOutputItems = new ItemStack[recipe.mOutputs.length];
 		        for (int i = 0; i < recipe.mOutputs.length; i++) {
-		            if (getBaseMetaTileEntity().getRandomNumber(10000) < tRecipe.getOutputChance(i)) {
+		            if (getBaseMetaTileEntity().getRandomNumber(10000) < recipe.getOutputChance(i)) {
 		                this.mOutputItems[i] = recipe.getOutput(i);
 		            }
 		        }

--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_MultiblockElectrolyzer.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_MultiblockElectrolyzer.java
@@ -139,7 +139,12 @@ public class GT_MetaTileEntity_MultiblockElectrolyzer  extends GT_MetaTileEntity
 
 				this.mEUt = -EUt;
 				this.mMaxProgresstime = maxProgresstime;
-				this.mOutputItems = recipe.mOutputs;
+				mOutputItems = new ItemStack[recipe.mOutputs.length];
+		        for (int i = 0; i < recipe.mOutputs.length; i++) {
+		            if (getBaseMetaTileEntity().getRandomNumber(10000) < tRecipe.getOutputChance(i)) {
+		                this.mOutputItems[i] = recipe.getOutput(i);
+		            }
+		        }
 				this.mOutputFluids = recipe.mFluidOutputs;
 				this.updateSlots();
 				return true;


### PR DESCRIPTION
I wrote a quick fix for Multiblock Electrolyzer/Centrifuge not applying output chances.
I did NOT test this fix because I changed operating systems and do not have a gregtech dev environment set up.
The problem with output chances seems to be that the Electrolyzer/Centrifuge never check for output chances because the code has been copied from the Large Chemical Reactor and that machine never made use of output chances.

I don't know what the problem with the NEI GUI is.
I'm not going to write a fix because it would take too much time.